### PR TITLE
Fix(wallet-contract): Always end with a callabck to unlock the contract

### DIFF
--- a/runtime/near-wallet-contract/implementation/wallet-contract/src/lib.rs
+++ b/runtime/near-wallet-contract/implementation/wallet-contract/src/lib.rs
@@ -8,8 +8,8 @@ use near_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
     env,
     json_types::U64,
-    near_bindgen, AccountId, Allowance, Gas, GasWeight, NearToken, Promise, PromiseOrValue,
-    PromiseResult,
+    near_bindgen, AccountId, Allowance, Gas, GasWeight, NearToken, Promise, PromiseError,
+    PromiseOrValue, PromiseResult,
 };
 use types::{EthEmulationKind, TransactionKind};
 
@@ -34,11 +34,12 @@ const NEP_141_STORAGE_DEPOSIT_AMOUNT: NearToken = NearToken::from_yoctonear(1_25
 const NEP_141_STORAGE_DEPOSIT_GAS: Gas = Gas::from_tgas(5);
 const NEP_141_STORAGE_BALANCE_OF_GAS: Gas = Gas::from_tgas(5);
 const REGISTRAR_LOOKUP_GAS: Gas = Gas::from_tgas(5);
-const RLP_EXECUTE_CALLBACK_GAS: Gas = Gas::from_tgas(5);
-const ADDRESS_CHECK_CALLBACK_GAS: Gas = Gas::from_tgas(5).saturating_add(RLP_EXECUTE_CALLBACK_GAS);
+const ACTION_CALLBACK_GAS: Gas = Gas::from_tgas(5);
+const FINALIZE_TX_GAS: Gas = Gas::from_tgas(5);
+const ADDRESS_CHECK_CALLBACK_GAS: Gas = Gas::from_tgas(5).saturating_add(ACTION_CALLBACK_GAS);
 const NEP_141_STORAGE_BALANCE_CALLBACK_GAS: Gas = Gas::from_tgas(5)
     .saturating_add(NEP_141_STORAGE_DEPOSIT_GAS)
-    .saturating_add(RLP_EXECUTE_CALLBACK_GAS);
+    .saturating_add(ACTION_CALLBACK_GAS);
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
@@ -135,9 +136,7 @@ impl WalletContract {
         &mut self,
         target: AccountId,
         action: near_action::Action,
-        caller_deposit: Option<CallerDeposit>,
     ) -> PromiseOrValue<ExecuteResponse> {
-        self.has_in_flight_tx = false;
         let maybe_account_id: Option<AccountId> = match env::promise_result(0) {
             PromiseResult::Failed => {
                 return PromiseOrValue::Value(ExecuteResponse {
@@ -176,18 +175,14 @@ impl WalletContract {
             // Recall that the nonce was not incremented in `inner_rlp_execute` in the case that
             // the registrar contract was called (i.e. in the case we end up inside this callback).
             self.nonce = self.nonce.saturating_add(1);
-            let ext =
-                WalletContract::ext(current_account_id).with_static_gas(RLP_EXECUTE_CALLBACK_GAS);
-            match action_to_promise(target, action)
-                .map(|p| p.then(ext.rlp_execute_callback(caller_deposit)))
-            {
+            let ext = WalletContract::ext(current_account_id).with_static_gas(ACTION_CALLBACK_GAS);
+            match action_to_promise(target, action).map(|p| p.then(ext.action_callback())) {
                 Ok(p) => p,
                 Err(e) => {
                     return PromiseOrValue::Value(e.into());
                 }
             }
         };
-        self.has_in_flight_tx = true;
         PromiseOrValue::Promise(promise)
     }
 
@@ -197,9 +192,7 @@ impl WalletContract {
         token_id: AccountId,
         receiver_id: AccountId,
         action: near_action::Action,
-        caller_deposit: Option<CallerDeposit>,
     ) -> PromiseOrValue<ExecuteResponse> {
-        self.has_in_flight_tx = false;
         let maybe_storage_balance: Option<StorageBalance> = match env::promise_result(0) {
             PromiseResult::Failed => {
                 return PromiseOrValue::Value(ExecuteResponse {
@@ -220,16 +213,14 @@ impl WalletContract {
             },
         };
         let current_account_id = env::current_account_id();
-        let ext = WalletContract::ext(current_account_id).with_static_gas(RLP_EXECUTE_CALLBACK_GAS);
+        let ext = WalletContract::ext(current_account_id).with_static_gas(ACTION_CALLBACK_GAS);
         let promise = match maybe_storage_balance {
             Some(_) => {
                 // receiver_id is registered so we can send the transfer
                 // without additional actions. Note: in the standard NEP-141
                 // implementation it is impossible to have `Some` storage balance,
                 // but have it be insufficient to transact.
-                match action_to_promise(token_id, action)
-                    .map(|p| p.then(ext.rlp_execute_callback(caller_deposit)))
-                {
+                match action_to_promise(token_id, action).map(|p| p.then(ext.action_callback())) {
                     Ok(p) => p,
                     Err(e) => {
                         return PromiseOrValue::Value(e.into());
@@ -265,23 +256,20 @@ impl WalletContract {
                         transfer_function_call.deposit,
                         transfer_function_call.gas,
                     )
-                    .then(ext.rlp_execute_callback(caller_deposit))
+                    .then(ext.action_callback())
             }
         };
-        self.has_in_flight_tx = true;
         PromiseOrValue::Promise(promise)
     }
 
+    /// Checks success or failure of the user's desired action
+    /// and returns an `ExecuteResponse`.
     #[private]
-    pub fn rlp_execute_callback(
-        &mut self,
-        caller_deposit: Option<CallerDeposit>,
-    ) -> ExecuteResponse {
-        self.has_in_flight_tx = false;
+    pub fn action_callback(&mut self) -> ExecuteResponse {
         let n = env::promise_results_count();
 
         if n == 0 {
-            // `rlp_execute_callback` is called directly in the case of an emulated self-transfer.
+            // `action_callback` is called directly in the case of an emulated self-transfer.
             return ExecuteResponse { success: true, success_value: None, error: None };
         } else if n > 1 {
             return ExecuteResponse {
@@ -294,25 +282,50 @@ impl WalletContract {
         }
 
         match env::promise_result(0) {
-            PromiseResult::Failed => {
-                // The cross-contract call failed, refund the caller if needed
-                if let Some(CallerDeposit { account_id, yocto_near }) = caller_deposit {
-                    let refund_promise = env::promise_batch_create(&account_id);
-                    env::promise_batch_action_transfer(
-                        refund_promise,
-                        NearToken::from_yoctonear(yocto_near.into()),
-                    );
-                }
-
-                ExecuteResponse {
-                    success: false,
-                    success_value: None,
-                    error: Some("Failed Near promise".into()),
-                }
-            }
+            PromiseResult::Failed => ExecuteResponse {
+                success: false,
+                success_value: None,
+                error: Some("Failed Near promise".into()),
+            },
             PromiseResult::Successful(value) => {
                 ExecuteResponse { success: true, success_value: Some(value), error: None }
             }
+        }
+    }
+
+    #[private]
+    pub fn finalize_tx(
+        &mut self,
+        caller_deposit: Option<CallerDeposit>,
+        #[callback_result] outcome: Result<ExecuteResponse, PromiseError>,
+    ) -> ExecuteResponse {
+        self.has_in_flight_tx = false;
+
+        // The caller gets their tokens back if the
+        // action was not executed successfully.
+        let refund_needed = outcome.as_ref().map_or(true, |r| !r.success);
+        if refund_needed {
+            if let Some(CallerDeposit { account_id, yocto_near }) = caller_deposit {
+                let refund_promise = env::promise_batch_create(&account_id);
+                env::promise_batch_action_transfer(
+                    refund_promise,
+                    NearToken::from_yoctonear(yocto_near.into()),
+                );
+            }
+        }
+
+        match outcome {
+            Ok(response) => response,
+            // If the prior receipt was an error then something went wrong
+            // internally (e.g. a receipt ran out of gas or there was not enough
+            // balance on the account for a storage deposit). If the user's action
+            // failed then `action_callback` would have returned an `ExecuteResponse`
+            // with `success: false`.
+            Err(_) => ExecuteResponse {
+                success: false,
+                success_value: None,
+                error: Some("Internal wallet contract failure".into()),
+            },
         }
     }
 
@@ -415,7 +428,7 @@ fn inner_rlp_execute(
             ..
         }) => {
             let callback_gas = ADDRESS_CHECK_CALLBACK_GAS.saturating_add(action.gas());
-            let ext = WalletContract::ext(current_account_id).with_static_gas(callback_gas);
+            let ext = WalletContract::ext(current_account_id.clone()).with_static_gas(callback_gas);
             let address_registrar = {
                 let account_id = ADDRESS_REGISTRAR_ACCOUNT_ID
                     .trim()
@@ -424,11 +437,7 @@ fn inner_rlp_execute(
                 ext_registrar::ext(account_id).with_static_gas(REGISTRAR_LOOKUP_GAS)
             };
             let address = format!("0x{}", hex::encode(address));
-            address_registrar.lookup(address).then(ext.address_check_callback(
-                target,
-                action,
-                caller_deposit,
-            ))
+            address_registrar.lookup(address).then(ext.address_check_callback(target, action))
         }
         TransactionKind::EthEmulation(EthEmulationKind::ERC20Transfer { receiver_id, .. }) => {
             // In the case of the emulated ERC-20 transfer, the receiving account
@@ -439,7 +448,7 @@ fn inner_rlp_execute(
             let token_id = target;
             let callback_gas = NEP_141_STORAGE_BALANCE_CALLBACK_GAS.saturating_add(action.gas());
             let ext: WalletContractExt =
-                WalletContract::ext(current_account_id).with_static_gas(callback_gas);
+                WalletContract::ext(current_account_id.clone()).with_static_gas(callback_gas);
             let storage_balance_args =
                 format!(r#"{{"account_id": "{}"}}"#, receiver_id.as_str()).into_bytes();
             Promise::new(token_id.clone())
@@ -449,27 +458,27 @@ fn inner_rlp_execute(
                     NearToken::from_yoctonear(0),
                     NEP_141_STORAGE_BALANCE_OF_GAS,
                 )
-                .then(ext.nep_141_storage_balance_callback(
-                    token_id,
-                    receiver_id,
-                    action,
-                    caller_deposit,
-                ))
+                .then(ext.nep_141_storage_balance_callback(token_id, receiver_id, action))
         }
         TransactionKind::EthEmulation(EthEmulationKind::SelfBaseTokenTransfer) => {
             // Base token transfers to self are no-ops on Near, so we do not need to
-            // schedule an additional call. We can simply go straight to `rlp_execute_callback`.
-            let ext: WalletContractExt =
-                WalletContract::ext(current_account_id).with_static_gas(RLP_EXECUTE_CALLBACK_GAS);
-            ext.rlp_execute_callback(caller_deposit)
+            // schedule an additional call. We can simply go straight to `action_callback`.
+            let ext: WalletContractExt = WalletContract::ext(current_account_id.clone())
+                .with_static_gas(ACTION_CALLBACK_GAS);
+            ext.action_callback()
         }
         _ => {
-            let ext =
-                WalletContract::ext(current_account_id).with_static_gas(RLP_EXECUTE_CALLBACK_GAS);
-            action_to_promise(target, action)?.then(ext.rlp_execute_callback(caller_deposit))
+            let ext = WalletContract::ext(current_account_id.clone())
+                .with_static_gas(ACTION_CALLBACK_GAS);
+            action_to_promise(target, action)?.then(ext.action_callback())
         }
     };
-    Ok(promise)
+
+    // After handling the user action promise, call `finalize_tx`.
+    // Including this promise here ensures it will always be executed
+    // regardless of if an error occurs in trying the handle the user's action.
+    let ext = WalletContract::ext(current_account_id).with_static_gas(FINALIZE_TX_GAS);
+    Ok(promise.then(ext.finalize_tx(caller_deposit)))
 }
 
 fn action_to_promise(target: AccountId, action: near_action::Action) -> Result<Promise, Error> {

--- a/runtime/near-wallet-contract/implementation/wallet-contract/src/tests/emulation.rs
+++ b/runtime/near-wallet-contract/implementation/wallet-contract/src/tests/emulation.rs
@@ -133,7 +133,7 @@ async fn test_base_token_transfer() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_base_token_transfer_with_relayer_refund() -> anyhow::Result<()> {
     const TRANSFER_AMOUNT: NearToken = NearToken::from_near(2);
-    const RELAYER_REFUND: NearToken = NearToken::from_millinear(1);
+    const RELAYER_REFUND: NearToken = NearToken::from_millinear(2);
     const GAS_LIMIT: u64 = 100_000;
 
     let TestContext { worker, wallet_contract, wallet_sk, wallet_contract_bytes, .. } =


### PR DESCRIPTION
Suggestion by @kondakovdmitry : define the callback which unlocks the contract during `rlp_execute`. This ensures it always executes regardless of what errors might happen with other callbacks that are handling the user's requested action.